### PR TITLE
Update excursion fields

### DIFF
--- a/components/Excursoes/ExcursaoCard.tsx
+++ b/components/Excursoes/ExcursaoCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
-import { MapPin, Calendar, Users, Clock } from 'lucide-react';
+import { MapPin, Calendar, Users } from 'lucide-react';
 import { Excursao } from '../../types';
 import { formatCurrency, formatDate } from '../../lib/api';
 
@@ -53,17 +53,12 @@ const ExcursaoCard: React.FC<ExcursaoCardProps> = ({ excursao, onClick }) => {
         <div className="space-y-2 mb-4">
           <div className="flex items-center text-sm text-gray-600">
             <MapPin className="h-4 w-4 mr-2 text-gray-400" />
-            <span>{excursao.destino}</span>
+            <span>{excursao.localDestino}</span>
           </div>
           
           <div className="flex items-center text-sm text-gray-600">
             <Calendar className="h-4 w-4 mr-2 text-gray-400" />
-            <span>{formatDate(excursao.dataIda)}</span>
-          </div>
-          
-          <div className="flex items-center text-sm text-gray-600">
-            <Clock className="h-4 w-4 mr-2 text-gray-400" />
-            <span>{excursao.horarioSaida}</span>
+            <span>{formatDate(excursao.dataSaida)}</span>
           </div>
           
           <div className="flex items-center text-sm text-gray-600">
@@ -78,11 +73,6 @@ const ExcursaoCard: React.FC<ExcursaoCardProps> = ({ excursao, onClick }) => {
             <span className="text-xl font-bold text-primary-600">
               {formatCurrency(excursao.preco)}
             </span>
-            {excursao.precoMenor && (
-              <div className="text-xs text-gray-500">
-                Criança: {formatCurrency(excursao.precoMenor)}
-              </div>
-            )}
           </div>
           
           <button 

--- a/components/Excursoes/ExcursaoFilters.tsx
+++ b/components/Excursoes/ExcursaoFilters.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { X } from 'lucide-react';
 
 interface Filters {
-  destino: string;
+  localDestino: string;
   precoMin: string;
   precoMax: string;
   dataInicio: string;
@@ -25,7 +25,7 @@ const ExcursaoFilters: React.FC<ExcursaoFiltersProps> = ({ filters, onFiltersCha
 
   const clearFilters = () => {
     onFiltersChange({
-      destino: '',
+      localDestino: '',
       precoMin: '',
       precoMax: '',
       dataInicio: '',
@@ -58,8 +58,8 @@ const ExcursaoFilters: React.FC<ExcursaoFiltersProps> = ({ filters, onFiltersCha
           <input
             type="text"
             placeholder="Ex: Rio de Janeiro"
-            value={filters.destino}
-            onChange={(e) => handleFilterChange('destino', e.target.value)}
+            value={filters.localDestino}
+            onChange={(e) => handleFilterChange('localDestino', e.target.value)}
             className="form-input"
           />
         </div>

--- a/components/Excursoes/InscricaoForm.tsx
+++ b/components/Excursoes/InscricaoForm.tsx
@@ -181,9 +181,15 @@ const InscricaoForm: React.FC<InscricaoFormProps> = ({ excursao, onClose, onSucc
               <div className="bg-gray-50 rounded-lg p-4">
                 <h3 className="font-semibold text-gray-900 mb-2">{excursao.titulo}</h3>
                 <div className="text-sm text-gray-600 space-y-1">
-                  <div>Destino: {excursao.destino}</div>
-                  <div>Data: {new Date(excursao.dataIda).toLocaleDateString('pt-BR')}</div>
-                  <div>Horário: {excursao.horarioSaida}</div>
+                  <div>Destino: {excursao.localDestino}</div>
+                  <div>Data: {new Date(excursao.dataSaida).toLocaleDateString('pt-BR')}</div>
+                  <div>
+                    Horário:
+                    {new Date(excursao.dataSaida).toLocaleTimeString('pt-BR', {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </div>
                   <div>Local de saída: {excursao.localSaida}</div>
                 </div>
               </div>

--- a/pages/cliente/dashboard.tsx
+++ b/pages/cliente/dashboard.tsx
@@ -79,8 +79,8 @@ const ClienteDashboard: React.FC = () => {
   const inscricoesConfirmadas = inscricoes.filter(i => i.status === 'CONFIRMADA');
   const inscricoesPendentes = inscricoes.filter(i => i.status === 'PENDENTE');
   const proximasViagens = inscricoesConfirmadas
-    .filter(i => new Date(i.excursao.dataIda) > new Date())
-    .sort((a, b) => new Date(a.excursao.dataIda).getTime() - new Date(b.excursao.dataIda).getTime());
+    .filter(i => new Date(i.excursao.dataSaida) > new Date())
+    .sort((a, b) => new Date(a.excursao.dataSaida).getTime() - new Date(b.excursao.dataSaida).getTime());
 
   return (
     <Layout 
@@ -158,13 +158,18 @@ const ClienteDashboard: React.FC = () => {
                         </h4>
                         <div className="flex items-center text-sm text-gray-600 mb-2">
                           <MapPin className="h-4 w-4 mr-1" />
-                          <span>{inscricao.excursao.destino}</span>
+                          <span>{inscricao.excursao.localDestino}</span>
                         </div>
                         <div className="flex items-center text-sm text-gray-600">
                           <Calendar className="h-4 w-4 mr-1" />
-                          <span>{formatDate(inscricao.excursao.dataIda)}</span>
+                          <span>{formatDate(inscricao.excursao.dataSaida)}</span>
                           <Clock className="h-4 w-4 ml-3 mr-1" />
-                          <span>{inscricao.excursao.horarioSaida}</span>
+                          <span>
+                            {new Date(inscricao.excursao.dataSaida).toLocaleTimeString('pt-BR', {
+                              hour: '2-digit',
+                              minute: '2-digit',
+                            })}
+                          </span>
                         </div>
                       </div>
                       <div className="text-right">

--- a/pages/excursoes/index.tsx
+++ b/pages/excursoes/index.tsx
@@ -15,7 +15,7 @@ const ExcursoesPage: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [showFilters, setShowFilters] = useState(false);
   const [filters, setFilters] = useState({
-    destino: '',
+    localDestino: '',
     precoMin: '',
     precoMax: '',
     dataInicio: '',
@@ -49,7 +49,7 @@ const ExcursoesPage: React.FC = () => {
 
   const filteredExcursoes = excursoes.filter(excursao =>
     excursao.titulo.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    excursao.destino.toLowerCase().includes(searchTerm.toLowerCase())
+    excursao.localDestino.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
   return (
@@ -138,7 +138,7 @@ const ExcursoesPage: React.FC = () => {
               onClick={() => {
                 setSearchTerm('');
                 setFilters({
-                  destino: '',
+                  localDestino: '',
                   precoMin: '',
                   precoMax: '',
                   dataInicio: '',

--- a/pages/organizador/excursoes/index.tsx
+++ b/pages/organizador/excursoes/index.tsx
@@ -67,7 +67,7 @@ const OrganizadorExcursoesPage: React.FC = () => {
 
   const filteredExcursoes = excursoes.filter(excursao =>
     excursao.titulo.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    excursao.destino.toLowerCase().includes(searchTerm.toLowerCase())
+    excursao.localDestino.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
   const getStatusBadge = (status: string) => {
@@ -242,12 +242,12 @@ const OrganizadorExcursoesPage: React.FC = () => {
                     <div className="space-y-2 mb-4">
                       <div className="flex items-center text-sm text-gray-600">
                         <MapPin className="h-4 w-4 mr-2 text-gray-400" />
-                        <span>{excursao.destino}</span>
+                        <span>{excursao.localDestino}</span>
                       </div>
                       
                       <div className="flex items-center text-sm text-gray-600">
                         <Calendar className="h-4 w-4 mr-2 text-gray-400" />
-                        <span>{formatDate(excursao.dataIda)}</span>
+                        <span>{formatDate(excursao.dataSaida)}</span>
                       </div>
                     </div>
 

--- a/pages/organizador/excursoes/nova.tsx
+++ b/pages/organizador/excursoes/nova.tsx
@@ -10,13 +10,11 @@ import toast from 'react-hot-toast';
 interface ExcursaoForm {
   titulo: string;
   descricao: string;
-  destino: string;
-  dataIda: string;
-  dataVolta?: string;
-  horarioSaida: string;
+  localDestino: string;
+  dataSaida: string;
+  dataRetorno?: string;
   localSaida: string;
   preco: number;
-  precoMenor?: number;
   vagasTotal: number;
   imagens: File[];
 }
@@ -28,7 +26,7 @@ const NovaExcursaoPage: React.FC = () => {
   
   const { register, handleSubmit, watch, formState: { errors } } = useForm<ExcursaoForm>();
 
-  const dataIda = watch('dataIda');
+  const dataSaida = watch('dataSaida');
 
   const onSubmit = async (data: ExcursaoForm) => {
     setIsLoading(true);
@@ -98,12 +96,12 @@ const NovaExcursaoPage: React.FC = () => {
                 type="text"
                 className="form-input"
                 placeholder="Ex: Campos do Jordão, SP"
-                {...register('destino', {
+                {...register('localDestino', {
                   required: 'Destino é obrigatório',
                 })}
               />
-              {errors.destino && (
-                <p className="mt-1 text-sm text-red-600">{errors.destino.message}</p>
+              {errors.localDestino && (
+                <p className="mt-1 text-sm text-red-600">{errors.localDestino.message}</p>
               )}
             </div>
 
@@ -142,54 +140,37 @@ const NovaExcursaoPage: React.FC = () => {
 
         {/* Date and Time */}
         <div className="card p-6">
-          <h3 className="section-title">Datas e Horários</h3>
+          <h3 className="section-title">Datas</h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div>
               <label className="form-label">
                 <Calendar className="inline h-4 w-4 mr-1" />
-                Data de Ida
+                Data de Saída
               </label>
               <input
-                type="date"
+                type="datetime-local"
                 className="form-input"
-                min={new Date().toISOString().split('T')[0]}
-                {...register('dataIda', {
-                  required: 'Data de ida é obrigatória',
+                min={new Date().toISOString().slice(0, 16)}
+                {...register('dataSaida', {
+                  required: 'Data de saída é obrigatória',
                 })}
               />
-              {errors.dataIda && (
-                <p className="mt-1 text-sm text-red-600">{errors.dataIda.message}</p>
+              {errors.dataSaida && (
+                <p className="mt-1 text-sm text-red-600">{errors.dataSaida.message}</p>
               )}
             </div>
 
             <div>
               <label className="form-label">
                 <Calendar className="inline h-4 w-4 mr-1" />
-                Data de Volta (Opcional)
+                Data de Retorno (Opcional)
               </label>
               <input
-                type="date"
+                type="datetime-local"
                 className="form-input"
-                min={dataIda}
-                {...register('dataVolta')}
+                min={dataSaida}
+                {...register('dataRetorno')}
               />
-            </div>
-
-            <div>
-              <label className="form-label">
-                <Clock className="inline h-4 w-4 mr-1" />
-                Horário de Saída
-              </label>
-              <input
-                type="time"
-                className="form-input"
-                {...register('horarioSaida', {
-                  required: 'Horário de saída é obrigatório',
-                })}
-              />
-              {errors.horarioSaida && (
-                <p className="mt-1 text-sm text-red-600">{errors.horarioSaida.message}</p>
-              )}
             </div>
           </div>
         </div>
@@ -219,19 +200,6 @@ const NovaExcursaoPage: React.FC = () => {
               )}
             </div>
 
-            <div>
-              <label className="form-label">Preço Criança (Opcional)</label>
-              <input
-                type="number"
-                step="0.01"
-                min="0"
-                className="form-input"
-                placeholder="0,00"
-                {...register('precoMenor', {
-                  min: { value: 0, message: 'Preço deve ser maior ou igual a zero' },
-                })}
-              />
-            </div>
 
             <div>
               <label className="form-label">


### PR DESCRIPTION
## Summary
- reference new excursion fields
- drop deprecated precoMenor and horarioSaida
- update form page to use new API names

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874343d4be88327a356e40c3f70644b