### PR TITLE
Add comment section and login callback

### DIFF
--- a/components/Excursoes/ComentarioSection.tsx
+++ b/components/Excursoes/ComentarioSection.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { useForm } from 'react-hook-form';
+import comentarioService from '../../services/comentarioService';
+import { Comentario } from '../../types';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+interface Props {
+  excursaoId: string;
+}
+
+const ComentarioSection: React.FC<Props> = ({ excursaoId }) => {
+  const { data: session } = useSession();
+  const router = useRouter();
+  const [comentarios, setComentarios] = useState<Comentario[]>([]);
+  const { register, handleSubmit, reset } = useForm<{ mensagem: string }>();
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await comentarioService.listar(excursaoId);
+        setComentarios(data);
+      } catch (err) {
+        console.error('Erro ao carregar comentários', err);
+      }
+    }
+    load();
+  }, [excursaoId]);
+
+  const onSubmit = async (data: { mensagem: string }) => {
+    try {
+      const novo = await comentarioService.criar(excursaoId, data.mensagem);
+      setComentarios((prev) => [novo, ...prev]);
+      reset();
+    } catch (err) {
+      console.error('Erro ao enviar comentário', err);
+    }
+  };
+
+  if (!session) {
+    const loginUrl = `/auth/login?callbackUrl=${encodeURIComponent(router.asPath)}`;
+    const registerUrl = `/auth/register?callbackUrl=${encodeURIComponent(router.asPath)}`;
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-gray-600">Entre para comentar sobre a excursão.</p>
+        <div className="flex space-x-2">
+          <Link href={loginUrl} className="btn-primary flex-1 text-center">Entrar</Link>
+          <Link href={registerUrl} className="btn-outline flex-1 text-center">Criar conta</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+        <textarea
+          className="form-input w-full"
+          placeholder="Deixe sua pergunta ou comentário"
+          {...register('mensagem', { required: true })}
+        />
+        <button type="submit" className="btn-primary">Enviar</button>
+      </form>
+
+      <ul className="space-y-3">
+        {comentarios.map((c) => (
+          <li key={c.id} className="border rounded p-3">
+            <div className="text-sm font-semibold">{c.autor.nome}</div>
+            <div className="text-sm text-gray-600">{new Date(c.createdAt).toLocaleString('pt-BR')}</div>
+            <p className="mt-1 text-gray-800">{c.mensagem}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ComentarioSection;

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -14,6 +14,7 @@ import toast from 'react-hot-toast';
 const LoginPage: React.FC = () => {
   const router = useRouter();
   const { redirectToDashboard } = useAuth();
+  const { callbackUrl } = router.query;
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   
@@ -39,23 +40,18 @@ const LoginPage: React.FC = () => {
       if (result?.error) {
         toast.error('Credenciais inválidas');
       } else {
-        // Aguardar a sessão ser atualizada
         const session = await getSession();
-        
         toast.success('Login realizado com sucesso!');
-        
-        // CORREÇÃO: Usar o método redirectToDashboard do useAuth
-        if (session?.userType) {
-          const dashboardUrl = session.userType === 'ORGANIZADOR' 
-            ? '/organizador/dashboard' 
+
+        const redirectUrl =
+          typeof callbackUrl === 'string'
+            ? (callbackUrl as string)
+            : session?.userType === 'ORGANIZADOR'
+            ? '/organizador/dashboard'
             : '/cliente/dashboard';
-          
-          console.log('🎯 Redirecionando após login para:', dashboardUrl);
-          router.push(dashboardUrl);
-        } else {
-          // Fallback usando useAuth
-          redirectToDashboard();
-        }
+
+        console.log('🎯 Redirecionando após login para:', redirectUrl);
+        router.push(redirectUrl);
       }
     } catch (error) {
       toast.error('Erro ao fazer login');
@@ -66,7 +62,13 @@ const LoginPage: React.FC = () => {
   };
 
   const handleGoogleSignIn = () => {
-    signIn('google', { callbackUrl: '/auth/complete-profile' });
+    const cb =
+      typeof callbackUrl === 'string'
+        ? `/auth/complete-profile?callbackUrl=${encodeURIComponent(
+            callbackUrl as string
+          )}`
+        : '/auth/complete-profile';
+    signIn('google', { callbackUrl: cb });
   };
 
   return (
@@ -101,7 +103,14 @@ const LoginPage: React.FC = () => {
             
             <p className="mt-2 text-center text-sm text-gray-600">
               Ou{' '}
-              <Link href="/auth/register" className="font-medium text-primary-600 hover:text-primary-500">
+              <Link
+                href={`/auth/register${
+                  typeof callbackUrl === 'string'
+                    ? `?callbackUrl=${encodeURIComponent(callbackUrl as string)}`
+                    : ''
+                }`}
+                className="font-medium text-primary-600 hover:text-primary-500"
+              >
                 crie uma nova conta
               </Link>
             </p>

--- a/pages/auth/register.tsx
+++ b/pages/auth/register.tsx
@@ -14,6 +14,7 @@ const RegisterPage: React.FC = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const { callbackUrl } = router.query;
   
   const { register, handleSubmit, watch, formState: { errors } } = useForm<RegisterOrganizadorForm>({
     defaultValues: {
@@ -60,9 +61,12 @@ const RegisterPage: React.FC = () => {
         toast.error('Erro no login automático');
         router.push('/auth/login');
       } else {
-        const redirectUrl = data.userType === 'ORGANIZADOR' 
-          ? '/organizador/dashboard' 
-          : '/cliente/dashboard';
+        const redirectUrl =
+          typeof callbackUrl === 'string'
+            ? (callbackUrl as string)
+            : data.userType === 'ORGANIZADOR'
+            ? '/organizador/dashboard'
+            : '/cliente/dashboard';
         router.push(redirectUrl);
       }
     } catch (error: any) {
@@ -76,7 +80,13 @@ const RegisterPage: React.FC = () => {
   };
 
   const handleGoogleSignIn = () => {
-    signIn('google', { callbackUrl: '/auth/complete-profile' });
+    const cb =
+      typeof callbackUrl === 'string'
+        ? `/auth/complete-profile?callbackUrl=${encodeURIComponent(
+            callbackUrl as string
+          )}`
+        : '/auth/complete-profile';
+    signIn('google', { callbackUrl: cb });
   };
 
   return (
@@ -94,7 +104,14 @@ const RegisterPage: React.FC = () => {
             </h2>
             <p className="mt-2 text-center text-sm text-gray-600">
               Ou{' '}
-              <Link href="/auth/login" className="font-medium text-primary-600 hover:text-primary-500">
+              <Link
+                href={`/auth/login${
+                  typeof callbackUrl === 'string'
+                    ? `?callbackUrl=${encodeURIComponent(callbackUrl as string)}`
+                    : ''
+                }`}
+                className="font-medium text-primary-600 hover:text-primary-500"
+              >
                 entre na sua conta existente
               </Link>
             </p>

--- a/pages/excursoes/[id].tsx
+++ b/pages/excursoes/[id].tsx
@@ -4,6 +4,7 @@ import { useSession } from 'next-auth/react';
 import Layout from '../../components/Layout';
 import ImageGallery from '../../components/Excursoes/ImageGallery';
 import InscricaoForm from '../../components/Excursoes/InscricaoForm';
+import ComentarioSection from '../../components/Excursoes/ComentarioSection';
 import { 
   MapPin, 
   Calendar, 
@@ -271,6 +272,12 @@ const ExcursaoDetailsPage: React.FC = () => {
                 </div>
               </div>
             </div>
+
+            {/* Perguntas e Comentários */}
+            <div className="card p-6">
+              <h2 className="section-title">Perguntas e Comentários</h2>
+              <ComentarioSection excursaoId={excursao.id} />
+            </div>
           </div>
 
           {/* Sidebar - Booking */}
@@ -309,13 +316,21 @@ const ExcursaoDetailsPage: React.FC = () => {
                     ) : (
                       <div className="space-y-3 mb-4">
                         <button
-                          onClick={() => router.push('/auth/login')}
+                          onClick={() =>
+                            router.push(
+                              `/auth/login?callbackUrl=${encodeURIComponent(router.asPath)}`
+                            )
+                          }
                           className="btn-primary w-full"
                         >
                           Entrar para se Inscrever
                         </button>
                         <button
-                          onClick={() => router.push('/auth/register')}
+                          onClick={() =>
+                            router.push(
+                              `/auth/register?callbackUrl=${encodeURIComponent(router.asPath)}`
+                            )
+                          }
                           className="btn-outline w-full"
                         >
                           Criar Conta

--- a/services/comentarioService.ts
+++ b/services/comentarioService.ts
@@ -1,0 +1,16 @@
+import api from './api';
+import { Comentario } from '../types';
+
+class ComentarioService {
+  async listar(excursaoId: string) {
+    const response = await api.get(`/public/excursoes/${excursaoId}/comentarios`);
+    return response.data.data as Comentario[];
+  }
+
+  async criar(excursaoId: string, mensagem: string) {
+    const response = await api.post(`/cliente/excursoes/${excursaoId}/comentarios`, { mensagem });
+    return response.data.data as Comentario;
+  }
+}
+
+export default new ComentarioService();

--- a/types/index.ts
+++ b/types/index.ts
@@ -54,6 +54,17 @@ export interface Inscricao {
   createdAt: string;
 }
 
+export interface Comentario {
+  id: string;
+  mensagem: string;
+  autor: {
+    id: string;
+    nome: string;
+    avatar?: string;
+  };
+  createdAt: string;
+}
+
 export interface Pagamento {
   id: string;
   valor: number;


### PR DESCRIPTION
## Summary
- allow passing callbackUrl to login and registration
- show login/register with callback from excursion details
- add comment section to excursions
- create service and types for comments

## Testing
- `npm install` *(fails: unable to reach registry)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874569e285c832796e33001f776b295